### PR TITLE
Fix: Add missing 'explorer-grid' class to dynamically created element.

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -592,7 +592,7 @@ class RituaLensApp {
         section.innerHTML = `
             <h2 class="font-serif text-5xl font-bold text-primary-100 mb-2 pb-2 border-b border-primary-700">${title}</h2>
             <p class="text-lg text-primary-400 mb-8 max-w-3xl">${description}</p>
-            <div class="grid grid-cols-[repeat(auto-fill,minmax(350px,1fr))] gap-6"></div>
+            <div class="explorer-grid grid grid-cols-[repeat(auto-fill,minmax(350px,1fr))] gap-6"></div>
         `;
         return section;
     }


### PR DESCRIPTION
A runtime error 'Cannot read properties of null (reading 'appendChild')' was occurring in the Lens Explorer view.

This was caused by the `renderLensExplorer` function querying for an element with the class `.explorer-grid` inside a section where the class was missing from the dynamically generated HTML.

This commit adds the required `explorer-grid` class to the `div` created within the `createExplorerSection` function, ensuring the querySelector does not return null and preventing the runtime error.